### PR TITLE
Moose::Exporter also enables strict/warnings

### DIFF
--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -252,6 +252,7 @@ sub modules_enabling_strict {
    Mojo::Base
    Moo
    Moose
+   Moose::Exporter
    Moose::Role
    MooseX::Declare
    MooseX::Types


### PR DESCRIPTION
Add Moose::Exporter to list of strict enabling modules.
