### PR TITLE
Allow customization of the modules that enable strict/warnings.

### DIFF
--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -67,7 +67,7 @@ use FindBin qw($Bin);
 use File::Find;
 use Config;
 
-use vars qw( $VERSION $PERL $COVERAGE_THRESHOLD $COVER $UNTAINT_PATTERN $PERL_PATTERN $CAN_USE_WARNINGS $TEST_SYNTAX $TEST_STRICT $TEST_WARNINGS $TEST_SKIP $DEVEL_COVER_OPTIONS $DEVEL_COVER_DB );
+use vars qw( $VERSION $PERL $COVERAGE_THRESHOLD $COVER $UNTAINT_PATTERN $PERL_PATTERN $CAN_USE_WARNINGS $TEST_SYNTAX $TEST_STRICT $TEST_WARNINGS $TEST_SKIP $DEVEL_COVER_OPTIONS $DEVEL_COVER_DB @MODULES_ENABLING_STRICT @MODULES_ENABLING_WARNINGS );
 $VERSION = '0.22';
 $PERL    = $^X || 'perl';
 $COVERAGE_THRESHOLD = 50; # 50%
@@ -234,77 +234,77 @@ sub _strict_ok {
 
 =head2 modules_enabling_strict
 
-Experimental. Returning a list of modules and pragmata that enable strict
+Experimental. Returning a list of modules and pragmata that enable strict.
+To modify this list, change C<@Test::Strict::MODULES_ENABLING_STRICT>.
 
 List taken from https://metacpan.org/source/DAXIM/Module-CPANTS-Analyse-0.86/lib/Module/CPANTS/Kwalitee/Uses.pm
 
 =cut
 
-sub modules_enabling_strict {
- return qw(
-   strict
-   Any::Moose
-   Class::Spiffy
-   Coat
-   common::sense
-   Dancer
-   Mo
-   Modern::Perl
-   Mojo::Base
-   Moo
-   Moose
-   Moose::Exporter
-   Moose::Role
-   MooseX::Declare
-   MooseX::Types
-   Mouse
-   Mouse::Role
-   perl5
-   perl5i::1
-   perl5i::2
-   perl5i::latest
-   Spiffy
-   strictures
- );
-}
+@MODULES_ENABLING_STRICT = qw(
+  strict
+  Any::Moose
+  Class::Spiffy
+  Coat
+  common::sense
+  Dancer
+  Mo
+  Modern::Perl
+  Mojo::Base
+  Moo
+  Moose
+  Moose::Exporter
+  Moose::Role
+  MooseX::Declare
+  MooseX::Types
+  Mouse
+  Mouse::Role
+  perl5
+  perl5i::1
+  perl5i::2
+  perl5i::latest
+  Spiffy
+  strictures
+);
+
+sub modules_enabling_strict { return @MODULES_ENABLING_STRICT }
 
 =head2 modules_enabling_warnings
 
-Experimental. Returning a list of modules and pragmata that enable strict
+Experimental. Returning a list of modules and pragmata that enable warnings
+To modify this list, change C<@Test::Strict::MODULES_ENABLING_WARNINGS>.
 
 List taken from https://metacpan.org/source/DAXIM/Module-CPANTS-Analyse-0.86/lib/Module/CPANTS/Kwalitee/Uses.pm
 
 =cut
 
-sub modules_enabling_warnings {
- return qw(
-    warnings
-    Any::Moose
-    Class::Spiffy
-    Coat
-    common::sense
-    Dancer
-    Mo
-    Modern::Perl
-    Mojo::Base
-    Moo
-    Moose
-    Moose::Exporter
-    Moose::Role
-    MooseX::Declare
-    MooseX::Types
-    Mouse
-    Mouse::Role
-    perl5
-    perl5i::1
-    perl5i::2
-    perl5i::latest
-    Spiffy
-    strictures
- );
-}
+@MODULES_ENABLING_WARNINGS = qw(
+  warnings
+  Any::Moose
+  Class::Spiffy
+  Coat
+  common::sense
+  Dancer
+  Mo
+  Modern::Perl
+  Mojo::Base
+  Moo
+  Moose
+  Moose::Exporter
+  Moose::Role
+  MooseX::Declare
+  MooseX::Types
+  Mouse
+  Mouse::Role
+  perl5
+  perl5i::1
+  perl5i::2
+  perl5i::latest
+  Spiffy
+  strictures
+);
 
-
+sub modules_enabling_warnings { return @MODULES_ENABLING_WARNINGS }
 
 =head2 warnings_ok( $file [, $text] )
 

--- a/t/01all.t
+++ b/t/01all.t
@@ -15,7 +15,7 @@ if ($^O =~ /MSWin/i) { # Load Win32 if we are under Windows and if module is ava
   }
 }
 
-my $tests = 37;
+my $tests = 39;
 $tests += 2 if -e 'blib/lib/Test/Strict.pm';
 plan  tests => $tests;
 
@@ -75,6 +75,20 @@ diag "File5: $warning_file5";
 warnings_ok( $warning_file5, 'file5' );
 
 {
+  my $warning_file6 = make_warning_file6();
+  diag "File6: $warning_file6";
+
+  local @Test::Strict::MODULES_ENABLING_WARNINGS
+    = (@Test::Strict::MODULES_ENABLING_WARNINGS, 'Custom');
+
+  local @Test::Strict::MODULES_ENABLING_STRICT
+    = (@Test::Strict::MODULES_ENABLING_STRICT, 'Custom');
+
+  warnings_ok( $warning_file6, 'file6' );
+  strict_ok( $warning_file6, 'file6' );
+}
+
+{
   my ($warnings_files_dir, $files, $file_to_skip) = make_warning_files();
   diag explain $files;
   diag "File to skip: $file_to_skip";
@@ -83,6 +97,7 @@ warnings_ok( $warning_file5, 'file5' );
   diag "Start all_perl_files_ok on $warnings_files_dir (should be 2*3 = 6 tests)";
   all_perl_files_ok( $warnings_files_dir );
 }
+
 exit;
 
 sub make_modern_perl_file1 {
@@ -169,6 +184,16 @@ DUMMY
   return $HAS_WIN32 ? Win32::GetLongPathName($filename) : $filename;
 }
 
+sub make_warning_file6 {
+  my $tmpdir = tempdir( CLEANUP => 1 );
+  my ($fh, $filename) = tempfile( DIR => $tmpdir, SUFFIX => '.pm' );
+  print $fh <<'DUMMY';
+use Custom;
+print "Hello world";
+
+DUMMY
+  return $HAS_WIN32 ? Win32::GetLongPathName($filename) : $filename;
+}
 
 sub make_warning_files {
   my $tmpdir = tempdir( CLEANUP => 1 );


### PR DESCRIPTION
There are several different ways to do this, but this seemed like the easiest.  Alternatively, you could create a function that adds modules to the strict/warning lists.  That way, you don't expose the internal variables.  On the other hand, a raw variable gives maximum flexibility.

I included a test case, but I found the current test code to be a bit janky.  And the POD has been updated too.
