### PR TITLE
Add a module that enables strict and warnings

### DIFF
--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -259,6 +259,7 @@ our @MODULES_ENABLING_STRICT = qw(
     common::sense
     Dancer
     HTML::FormHandler::Moose
+    HTML::FormHandler::Moose::Role
     Mo
     Modern::Perl
     Mojo::Base
@@ -302,6 +303,7 @@ our @MODULES_ENABLING_WARNINGS = qw(
     common::sense
     Dancer
     HTML::FormHandler::Moose
+    HTML::FormHandler::Moose::Role
     Mo
     Modern::Perl
     Mojo::Base

--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -258,6 +258,7 @@ our @MODULES_ENABLING_STRICT = qw(
     Coat
     common::sense
     Dancer
+    HTML::FormHandler::Moose
     Mo
     Modern::Perl
     Mojo::Base
@@ -300,6 +301,7 @@ our @MODULES_ENABLING_WARNINGS = qw(
     Coat
     common::sense
     Dancer
+    HTML::FormHandler::Moose
     Mo
     Modern::Perl
     Mojo::Base


### PR DESCRIPTION
HTML::FormHandler::Moose uses Moose::Exporter to export strict and
warnings to classes that use it.