### PR TITLE
Improve implicit-stricture support

### DIFF
--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -224,6 +224,7 @@ sub strict_ok {
 
 sub _strict_ok {
     my ($in) = @_;
+    local $_;
     while (<$in>) {
         next if (/^\s*#/); # Skip comments
         next if (/^\s*=.+/ .. /^\s*=(cut|back|end)/); # Skip pod
@@ -367,6 +368,7 @@ sub warnings_ok {
 # TODO unite with _strict_ok
 sub _warnings_ok {
     my ($is_script, $in) = @_;
+    local $_;
     while (<$in>) {
         if ($. == 1 and $is_script and $_ =~ $PERL_PATTERN) {
             if (/\s+-\w*[wW]/) {

--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -237,6 +237,9 @@ sub _strict_ok {
         if (/\buse\s+(5\.\d+)/ and $1 >= 5.012) {
             return 1;
         }
+        if (/\buse\s+v5\.(\d+)/ and $1 >= 12) {
+            return 1;
+        }
     }
     return;
 }

--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -234,7 +234,7 @@ sub _strict_ok {
                 return 1;
             }
         }
-        if (/\buse\s+(5.01\d+)/ and $1 >= 5.012) {
+        if (/\buse\s+(5\.\d+)/ and $1 >= 5.012) {
             return 1;
         }
     }

--- a/t/01all.t
+++ b/t/01all.t
@@ -15,7 +15,7 @@ if ($^O =~ /MSWin/i) { # Load Win32 if we are under Windows and if module is ava
   }
 }
 
-my $tests = 54;
+my $tests = 55;
 $tests += 2 if -e 'blib/lib/Test/Strict.pm';
 plan  tests => $tests;
 
@@ -115,6 +115,13 @@ subtest perl5_20 => sub {
   plan tests => 1;
 
   my $filename = make_file("$tmpdir/perl5_20.pl", 'perl5_20');
+  strict_ok($filename);
+};
+
+subtest perl_v5_12 => sub {
+  plan tests => 1;
+
+  my $filename = make_file("$tmpdir/perl_v5_12.pl", 'perl_v5_12');
   strict_ok($filename);
 };
 
@@ -261,6 +268,12 @@ $x = 23;
 
 perl5_20
 use 5.020;
+
+$x = 23;
+---------
+
+perl_v5_12
+use v5.12;
 
 $x = 23;
 ---------

--- a/t/01all.t
+++ b/t/01all.t
@@ -15,7 +15,7 @@ if ($^O =~ /MSWin/i) { # Load Win32 if we are under Windows and if module is ava
   }
 }
 
-my $tests = 53;
+my $tests = 54;
 $tests += 2 if -e 'blib/lib/Test/Strict.pm';
 plan  tests => $tests;
 
@@ -108,6 +108,13 @@ subtest perl5_12 => sub {
   plan tests => 1;
 
   my $filename = make_file("$tmpdir/perl5_12.pl", 'perl5_12');
+  strict_ok($filename);
+};
+
+subtest perl5_20 => sub {
+  plan tests => 1;
+
+  my $filename = make_file("$tmpdir/perl5_20.pl", 'perl5_20');
   strict_ok($filename);
 };
 
@@ -248,6 +255,12 @@ print "Hello world";
 ---------
 perl5_12
 use 5.012;
+
+$x = 23;
+---------
+
+perl5_20
+use 5.020;
 
 $x = 23;
 ---------


### PR DESCRIPTION
This fixes a couple of problems with implicit strictures, as enabled by `use 5.012`:

* `use 5.020` wasn't being treated as >= `use 5.012`
* `use v5.12` wasn't being treated as equivalent to `use 5.012`

It also ensures that `$_` is localized before being set by `while (<>)`

Please let me know if you'd like me to rework this pull request in any way.

Thanks.