### PR TITLE
Performance improvement and another strict/warnings module

### DIFF
--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -288,6 +288,7 @@ our @MODULES_ENABLING_STRICT = qw(
     Role::Tiny
     Spiffy
     strictures
+    Test::Roo
 );
 
 sub modules_enabling_strict { return @MODULES_ENABLING_STRICT }
@@ -332,6 +333,7 @@ our @MODULES_ENABLING_WARNINGS = qw(
     Role::Tiny
     Spiffy
     strictures
+    Test::Roo
 );
 
 sub modules_enabling_warnings { return @MODULES_ENABLING_WARNINGS }


### PR DESCRIPTION
This branch adds Test::Roo to the list of modules enabling strict and warnings. It also provides a factor-of-10 performance improvement for detecting usage of strict/warnings modules.

Please let me know if you'd like me to rework this PR in any way.

Thanks!