### PR TITLE
fix skipping of .git, .svn, and CVS directories

### DIFF
--- a/lib/Test/Strict.pm
+++ b/lib/Test/Strict.pm
@@ -130,7 +130,7 @@ sub _all_files {
         #return if ($File::Find::dir =~ m![\\/]?blib[\\/]libdoc$!); # Filter out pod doc in dist
         #return if ($File::Find::dir =~ m![\\/]?blib[\\/]man\d$!); # Filter out pod doc in dist
         if (-d $File::Find::name &&
-            ($_ eq 'CVS' || $_ eq '.svn' || $_ eq '.git' || # Filter out cvs or git or subversion dirs
+            ($File::Find::name =~ m!(?:^|[\\/])(?:CVS|\.svn|\.git)$! || # Filter out cvs or git or subversion dirs
              $File::Find::name =~ m!(?:^|[\\/])blib[\\/]libdoc$! || # Filter out pod doc in dist
              $File::Find::name =~ m!(?:^|[\\/])blib[\\/]man\d$!) # Filter out pod doc in dist
             ) {

--- a/t/01all.t
+++ b/t/01all.t
@@ -15,7 +15,7 @@ if ($^O =~ /MSWin/i) { # Load Win32 if we are under Windows and if module is ava
   }
 }
 
-my $tests = 57;
+my $tests = 55;
 $tests += 2 if -e 'blib/lib/Test/Strict.pm';
 plan  tests => $tests;
 


### PR DESCRIPTION
Inside a File::Find wanted sub, $_ will have the full path to the file or directory if run with no_chdir. Change the check for .git, .svn, and CVS directories to use a regex on $File::Find::name to account for this.