### PR TITLE
remove redundant checkmanifest test which is broken when running from a git checkout

### DIFF
--- a/t/92-manifest.t
+++ b/t/92-manifest.t
@@ -1,7 +1,0 @@
-use strict;
-use warnings;
-use Test::More;
-
-eval 'use Test::DistManifest 1.012';
-plan skip_all => 'Test::DistManifest 1.012 required to test MANIFEST' if $@;
-manifest_ok();

--- a/t/93-checkmanifest.t
+++ b/t/93-checkmanifest.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
-use Test::More;
+use Test::More tests => 2;
+use ExtUtils::Manifest;
 
-eval 'use Test::CheckManifest 1.28';
-plan skip_all => 'Test::CheckManifest 1.28 required to test MANIFEST' if $@;
-ok_manifest();
+is_deeply [ ExtUtils::Manifest::manicheck() ], [], 'missing';
+is_deeply [ ExtUtils::Manifest::filecheck() ], [], 'extra';


### PR DESCRIPTION
Test::CheckManifest is broken when run from a git checkout, so stop using it. There is already a test using Test::DistManifest, so it was redundant anyway.